### PR TITLE
Check if table exists within onCanonicalNamespaces

### DIFF
--- a/src/NamespaceRepository.php
+++ b/src/NamespaceRepository.php
@@ -53,9 +53,9 @@ class NamespaceRepository {
 	 * @return int
 	 */
 	public static function getNextAvailableNamespaceId(): int {
-                $dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnectionRef( DB_MASTER );
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnectionRef( DB_MASTER );
 
-                $result = $dbr->newSelectQueryBuilder()->select(
+		$result = $dbr->newSelectQueryBuilder()->select(
 			'namespace_id'
 		)->from(
 			  'wss_namespaces'

--- a/src/NamespaceRepository.php
+++ b/src/NamespaceRepository.php
@@ -114,7 +114,7 @@ class NamespaceRepository {
 			]
 		)->from(
 			'wss_namespaces'
-		)->fetchResultSet();
+		)->caller( __METHOD__ )->fetchResultSet();
 
 		$buffer = [];
 		foreach ( $result as $item ) {
@@ -151,7 +151,7 @@ class NamespaceRepository {
 			[
 				'namespace_id' => $namespace_id
 			]
-		)->fetchResultSet();
+		)->caller( __METHOD__ )->fetchResultSet();
 
 		$buffer = [];
 		foreach ( $result as $item ) {
@@ -515,7 +515,7 @@ class NamespaceRepository {
 			[
 				'archived' => $archived
 			]
-		)->fetchResultSet();
+		)->caller( __METHOD__ )->fetchResultSet();
 
 		$buffer = [];
 

--- a/src/NamespaceRepository.php
+++ b/src/NamespaceRepository.php
@@ -60,7 +60,7 @@ class NamespaceRepository {
                 $dbr = self::getDBLoadBalancer->getConnectionRef( DB_MASTER );
                 $result = $dbr->newSelectQueryBuilder()->select(
 			'namespace_id'
-                )->from(
+		)->from(
 			  'wss_namespaces'
 		)->orderBy(
 			'namespace_id',
@@ -496,6 +496,9 @@ class NamespaceRepository {
 	 */
 	private function getSpacesOnArchived( bool $archived ): array {
 		$dbr = $this->dbLoadBalancer->getConnectionRef( DB_REPLICA );
+		if ( !$dbr->tableExists( 'wss_namespaces', __METHOD__ ) ) {
+			return [];
+		}
 		$result = $dbr->newSelectQueryBuilder()->select(
 			[
 				'namespace_id',

--- a/src/Space.php
+++ b/src/Space.php
@@ -133,7 +133,7 @@ class Space {
 	 * @throws \ConfigException
 	 */
 	public static function newFromConstant( int $namespace_constant ) {
-		$dbr = self::getDBLoadBalancer()->getConnectionRef( DB_REPLICA );
+		$dbr = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnectionRef( DB_REPLICA );
 
 		// It might happen that this function is called during run of update.php,
 		// while database is not property set up. In that case, give a sensible return value.
@@ -342,7 +342,7 @@ class Space {
 	 */
 	public function exists(): bool {
 		// Get DB_MASTER to ensure integrity
-		$database = self::getDBLoadBalancer()->getConnectionRef( DB_MASTER );
+		$database = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnectionRef( DB_MASTER );
 
 		// If database has not been set up yet (e.g. during update.php run), namespace does not exist yet.
 		if ( !$database->tableExists( 'wss_namespaces', __METHOD__ ) ) {
@@ -354,7 +354,7 @@ class Space {
 			'wss_namespaces'
 		)->where(
 			[ 'namespace_id' => $this->namespace_id ]
-		)->fetchField();
+		)->caller( __METHOD__ )->fetchField();
 
 		return $result !== false && $this->namespace_id !== self::DEFAULT_NAMESPACE_CONSTANT;
 	}
@@ -393,10 +393,5 @@ class Space {
 			);
 
 		return $services->getMainConfig()->get( "WSSpacesEnableSpaceArchiving" ) && $user_can_archive;
-	}
-
-	private static function getDBLoadBalancer()
-	{
-		return MediaWikiServices::getInstance()->getDBLoadBalancer();
 	}
 }

--- a/src/Space.php
+++ b/src/Space.php
@@ -336,7 +336,11 @@ class Space {
 	 * @return bool
 	 */
 	public function exists(): bool {
+		// Get DB_MASTER to ensure integrity
 		$database = self::getDBLoadBalancer()->getConnectionRef( DB_MASTER );
+		if ( !$database->tableExists( 'wss_namespaces', __METHOD__ ) ) {
+			return false;
+		}
 		$result = $database->newSelectQueryBuilder()->select(
 			[ 'namespace_id' ]
 		)->from(

--- a/src/Validation/AbstractValidationCallback.php
+++ b/src/Validation/AbstractValidationCallback.php
@@ -2,25 +2,7 @@
 
 namespace WSS\Validation;
 
-use MediaWiki\MediaWikiServices;
-
 abstract class AbstractValidationCallback {
-	/* A DBLoadBalancer for database access */
-	protected $dbLoadBalancer = null;
-
-	/**
-	 * Get a DBLoadBalancer for database access
-	 *
-	 * @return DBLoadBalancer
-	 */
-	protected function getDBLoadBalancer()
-	{
-		if (null === $this->dbLoadBalancer) {
-			$this->dbLoadBalancer = MediaWikiServices::getInstance()->getDBLoadBalancer();
-		}
-		return $this->dbLoadBalancer;
-	}
-
 	/**
 	 * Validates whether the given value is allowed for the given field.
 	 *

--- a/src/Validation/AbstractValidationCallback.php
+++ b/src/Validation/AbstractValidationCallback.php
@@ -2,7 +2,25 @@
 
 namespace WSS\Validation;
 
+use MediaWiki\MediaWikiServices;
+
 abstract class AbstractValidationCallback {
+	/* A DBLoadBalancer for database access */
+	protected $dbLoadBalancer = null;
+
+	/**
+	 * Get a DBLoadBalancer for database access
+	 *
+	 * @return DBLoadBalancer
+	 */
+	protected function getDBLoadBalancer()
+	{
+		if (null === $this->dbLoadBalancer) {
+			$this->dbLoadBalancer = MediaWikiServices::getInstance()->getDBLoadBalancer();
+		}
+		return $this->dbLoadBalancer;
+	}
+
 	/**
 	 * Validates whether the given value is allowed for the given field.
 	 *

--- a/src/Validation/AddSpaceValidationCallback.php
+++ b/src/Validation/AddSpaceValidationCallback.php
@@ -71,10 +71,16 @@ class AddSpaceValidationCallback extends AbstractValidationCallback {
 	 */
 	private function validateNamespaceName( $value, array $form_data ) {
 		// Get DB_MASTER to ensure integrity
-		$database = wfGetDB( DB_MASTER );
-		$namespaces = $database->select( "wss_namespaces", [ "namespace_id" ], [ "namespace_name" => $value ] );
+		$database = $this->getDBLoadBalancer()->getConnectionRef( DB_MASTER );
+		$namespace = $database->newSelectQueryBuilder()->select(
+			"namespace_id"
+		)->from(
+			"wss_namespaces"
+		)->where(
+			[ "namespace_name" => $value ]
+		)->caller( __METHOD__ )->fetchField();
 
-		if ( $namespaces->numRows() === 0 ) {
+		if ( $namespace === false ) {
 			// There are no spaces with this name
 			return true;
 		}

--- a/src/Validation/AddSpaceValidationCallback.php
+++ b/src/Validation/AddSpaceValidationCallback.php
@@ -71,7 +71,8 @@ class AddSpaceValidationCallback extends AbstractValidationCallback {
 	 */
 	private function validateNamespaceName( $value, array $form_data ) {
 		// Get DB_MASTER to ensure integrity
-		$database = $this->getDBLoadBalancer()->getConnectionRef( DB_MASTER );
+		$database = MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnectionRef( DB_MASTER );
+
 		$namespace = $database->newSelectQueryBuilder()->select(
 			"namespace_id"
 		)->from(


### PR DESCRIPTION
There was a problem that `onCanonicalNamespaces` was called during initialisation of `update.php` because of some flow hook being called. However, the database table didn't exist yet (That's why we ran `update.php`).

Stack trace:
```
#0 /var/www/./public_html/includes/libs/rdbms/database/Database.php(1697): Wikimedia\Rdbms\Database->getQueryException()
#1 /var/www/./public_html/includes/libs/rdbms/database/Database.php(1672): Wikimedia\Rdbms\Database->getQueryExceptionAndLog()
#2 /var/www/./public_html/includes/libs/rdbms/database/Database.php(1241): Wikimedia\Rdbms\Database->reportQueryError()
#3 /var/www/./public_html/includes/libs/rdbms/database/Database.php(1921): Wikimedia\Rdbms\Database->query()
#4 /var/www/./public_html/includes/libs/rdbms/database/DBConnRef.php(68): Wikimedia\Rdbms\Database->select()
#5 /var/www/./public_html/includes/libs/rdbms/database/DBConnRef.php(313): Wikimedia\Rdbms\DBConnRef->__call()
#6 /var/www/./public_html/extensions/WSSpaces/src/NamespaceRepository.php(481): Wikimedia\Rdbms\DBConnRef->select()
#7 /var/www/./public_html/extensions/WSSpaces/src/NamespaceRepository.php(147): WSS\NamespaceRepository->getSpacesOnArchived()
#8 /var/www/./public_html/extensions/WSSpaces/src/WSSHooks.php(191): WSS\NamespaceRepository->getSpaces()
#9 /var/www/./public_html/includes/HookContainer/HookContainer.php(329): WSS\WSSHooks::onCanonicalNamespaces()
#10 /var/www/./public_html/includes/HookContainer/HookContainer.php(132): MediaWiki\HookContainer\HookContainer->callLegacyHook()
#11 /var/www/./public_html/includes/HookContainer/HookRunner.php(1094): MediaWiki\HookContainer\HookContainer->run()
#12 /var/www/./public_html/includes/title/NamespaceInfo.php(398): MediaWiki\HookContainer\HookRunner->onCanonicalNamespaces()
#13 /var/www/./public_html/languages/Language.php(588): NamespaceInfo->getCanonicalNamespaces()
#14 /var/www/./public_html/languages/Language.php(664): Language->getNamespaces()
#15 /var/www/./public_html/includes/title/MediaWikiTitleCodec.php(109): Language->getNsText()
#16 /var/www/./public_html/includes/title/MediaWikiTitleCodec.php(139): MediaWikiTitleCodec->getNamespaceName()
#17 /var/www/./public_html/includes/title/MediaWikiTitleCodec.php(261): MediaWikiTitleCodec->formatTitle()
#18 /var/www/./public_html/includes/cache/LinkCache.php(245): MediaWikiTitleCodec->getPrefixedDBkey()
#19 /var/www/./public_html/includes/Title.php(3246): LinkCache->addLinkObj()
#20 /var/www/./public_html/includes/Revision/RevisionStore.php(2883): Title->getArticleID()
#21 /var/www/./public_html/includes/cache/MessageCache.php(1196): MediaWiki\Revision\RevisionStore->getKnownCurrentRevision()
#22 /var/www/./public_html/includes/libs/objectcache/wancache/WANObjectCache.php(1529): MessageCache->{closure}()
#23 /var/www/./public_html/includes/libs/objectcache/wancache/WANObjectCache.php(1376): WANObjectCache->fetchOrRegenerate()
#24 /var/www/./public_html/includes/cache/MessageCache.php(1222): WANObjectCache->getWithSetCallback()
#25 /var/www/./public_html/includes/libs/objectcache/BagOStuff.php(149): MessageCache->{closure}()
#26 /var/www/./public_html/includes/cache/MessageCache.php(1224): BagOStuff->getWithSetCallback()
#27 /var/www/./public_html/includes/cache/MessageCache.php(1137): MessageCache->loadCachedMessagePageEntry()
#28 /var/www/./public_html/includes/cache/MessageCache.php(1034): MessageCache->getMsgFromNamespace()
#29 /var/www/./public_html/includes/cache/MessageCache.php(1005): MessageCache->getMessageForLang()
#30 /var/www/./public_html/includes/cache/MessageCache.php(947): MessageCache->getMessageFromFallbackChain()
#31 /var/www/./public_html/includes/language/Message.php(1320): MessageCache->get()
#32 /var/www/./public_html/includes/language/Message.php(878): Message->fetchMessage()
#33 /var/www/./public_html/includes/Message/TextFormatter.php(51): Message->toString()
#34 /var/www/./public_html/includes/user/UserNameUtils.php(195): MediaWiki\Message\TextFormatter->format()
#35 /var/www/./public_html/includes/user/UserNameUtils.php(300): MediaWiki\User\UserNameUtils->isUsable()
#36 /var/www/./public_html/includes/user/User.php(1150): MediaWiki\User\UserNameUtils->getCanonical()
#37 /var/www/./public_html/includes/auth/TemporaryPasswordPrimaryAuthenticationProvider.php(184): User::getCanonicalName()
#38 /var/www/./public_html/includes/auth/AuthManager.php(814): MediaWiki\Auth\TemporaryPasswordPrimaryAuthenticationProvider->testUserCanAuthenticate()
#39 /var/www/./public_html/includes/user/User.php(3118): MediaWiki\Auth\AuthManager->userCanAuthenticate()
#40 /var/www/./public_html/includes/user/User.php(842): User->isSystemUser()
#41 /var/www/./public_html/extensions/Flow/includes/TalkpageManager.php(180): User::newSystemUser()
#42 /var/www/./public_html/extensions/Flow/includes/Conversion/Utils.php(590): Flow\TalkpageManager->getTalkpageManager()
#43 /var/www/./public_html/extensions/Flow/includes/Conversion/Utils.php(353): Flow\Conversion\Utils::generateForwardedCookieForCli()
#44 /var/www/./public_html/extensions/Flow/includes/Conversion/Utils.php(282): Flow\Conversion\Utils::makeVRSObject()
#45 /var/www/./public_html/extensions/Flow/includes/Conversion/Utils.php(250): Flow\Conversion\Utils::getVRSObject()
#46 /var/www/./public_html/extensions/Flow/includes/Hooks.php(200): Flow\Conversion\Utils::isParsoidConfigured()
#47 /var/www/./public_html/includes/Setup.php(806): Flow\Hooks::initFlowExtension()
#48 /var/www/./public_html/maintenance/doMaintenance.php(91): require_once(string)
#49 /var/www/./public_html/maintenance/update.php(253): require_once(string)
#50 {main}
```