### PR TITLE
Check if namespace admins exist

### DIFF
--- a/src/WSSHooks.php
+++ b/src/WSSHooks.php
@@ -61,7 +61,8 @@ abstract class WSSHooks {
 		// Turn the list of admin ids into User objects
 		$admins = array_map( [ User::class, "newFromId" ], $admin_ids );
 		$admins = array_filter( $admins, function ( $user ): bool {
-			return $user instanceof User;
+			// loadFromDatabase checks if the user actually exists in the database.
+			return $user instanceof User && $user->loadFromDatabase();
 		} );
 
 		if ( empty( $admins ) ) {


### PR DESCRIPTION
see issue: [unknown user returned by `#spaceadmins`](https://github.com/Open-CSP/WSSpaces/issues/4).

User::newFromID always returns a user, so the "instanceOf" check is a bit redundant (But we can keep it for paranoia reasons).

Note that `user->isRegistered()` cannot be used: It just checks the user id, which has been set. So we need `loadFromDatabase()`.