### PR TITLE
Add wss_namespace_admins to usermerge tables to merge list

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -29,7 +29,8 @@
     "LoadExtensionSchemaUpdates": "WSS\\WSSHooks::onLoadExtensionSchemaUpdates",
     "CanonicalNamespaces": "WSS\\WSSHooks::onCanonicalNamespaces",
     "ExtensionTypes": "WSS\\WSSHooks::onExtensionTypes",
-    "ParserFirstCallInit": "WSS\\WSSHooks::onParserFirstCallInit"
+    "ParserFirstCallInit": "WSS\\WSSHooks::onParserFirstCallInit",
+    "UserMergeAccountFields": "WSS\\WSSHooks::onUserMergeAccountFields"
   },
   "SpecialPages": {
     "AddSpace": "WSS\\Special\\SpecialAddSpace",

--- a/src/WSSHooks.php
+++ b/src/WSSHooks.php
@@ -219,6 +219,17 @@ abstract class WSSHooks {
 	}
 
 	/**
+	 * A hook of the UserMerge extension: If a user is merged, do migrate the admin table accordingly
+	 *
+	 * @see https://www.mediawiki.org/wiki/Extension:UserMerge/Hooks/UserMergeAccountFields
+	 *
+	 * @param array &$updateFields The fields as described on the documentation page
+	 */
+	public static function onUserMergeAccountFields( &$updateFields ) {
+		$updateFields []= [ 'wss_namespace_admins', 'admin_user_id', 'options' => [ 'IGNORE' ] ];
+	}
+
+	/**
 	 * Called when generating the extensions credits, use this to change the tables headers.
 	 *
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ExtensionTypes


### PR DESCRIPTION
See [hook documentation](https://www.mediawiki.org/wiki/Extension:UserMerge/Hooks/UserMergeAccountFields) and [relevant usermerge code](https://github.com/wikimedia/mediawiki-extensions-UserMerge/blob/ddc5c18af3664ad043f608910015b70f7e7ba764/includes/MergeUser.php#L273)

Related to [issue about admins not being merged](https://github.com/Open-CSP/WSSpaces/issues/4)
