### PR TITLE
Add missing import for MediaWikiServices in AddSpaceValidationCallback

### DIFF
--- a/src/Validation/AddSpaceValidationCallback.php
+++ b/src/Validation/AddSpaceValidationCallback.php
@@ -2,6 +2,7 @@
 
 namespace WSS\Validation;
 
+use MediaWiki\MediaWikiServices;
 use WSS\NamespaceRepository;
 use WSS\Space;
 


### PR DESCRIPTION
Made an oopsie in https://github.com/Open-CSP/WSSpaces/pull/3