### PR TITLE
Enable editing on non-protected spaces

### DIFF
--- a/src/Space.php
+++ b/src/Space.php
@@ -484,7 +484,7 @@ class Space {
 	 */
 	public function canEditPages( $user = null ): bool {
 		$user ??= \RequestContext::getMain()->getUser();
-		return MediaWikiServices::getInstance()->getPermissionManager()->userHasRight(
+		return !$this->is_protected || MediaWikiServices::getInstance()->getPermissionManager()->userHasRight(
 			$user,
 			"wss-edit-protected"
 		);


### PR DESCRIPTION
We would like to be able to edit pages that are not protected, ooops