### PR TITLE
Protected spaces functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ for ($i = 50000; $i < 55000; $i++) {
 
 You can use the `{{#spaces:}}` parser function to get a comma-separated list of spaces defined by WSSpaces.
 
+### Retrieving data for a space
+
+You can use the `{{#spaceadmins:{{NAMESPACENUMBER}}}}` and `{{#spacedescription:{{NAMESPACENUMBER}}}}` and `{{#spacename:{{NAMESPACENUMBER}}}}` parser functions to get the list of admin names, description of the space, and long name of the space with Wikitext.
+
 ## Hooks
 
 WSSpaces defines several hooks to alter or extend its behaviour.
@@ -53,6 +57,7 @@ WSSpaces defines several rights.
 
 > Please note that administrators of a space are always able to edit the details of that
 > space, regardless of whether or not they have been assigned any of the rights below.
+> However, admins do not get the wss-edit-protected right by default, so they cannot edit "pages" in protected spaces.
 
 ### `wss-edit-all-spaces`
 
@@ -76,6 +81,10 @@ Whether the user is able to view the admins for a space or not.
 
 Whether the user is able to view the overview of spaces or not.
 
+### `wss-edit-protected`
+
+Whether the user is able to edit pages in "protected" spaces.
+
 ## API modules
 
 WSSpaces defines several API modules. The documentation of these API modules can be found through
@@ -91,3 +100,4 @@ Furthermore, the following API list (`?action=query`) modules are available:
 
 * `spaces`
 * `spaceadmins`
+* `singlespace`

--- a/extension.json
+++ b/extension.json
@@ -25,6 +25,7 @@
   },
   "Hooks": {
     "SecuritySensitiveOperationStatus": "WSS\\WSSHooks::onSecuritySensitiveOperationStatus",
+    "getUserPermissionsErrors": "WSS\\WSSHooks::onGetUserPermissionsErrors",
     "SkinBuildSidebar": "WSS\\WSSHooks::onSkinBuildSidebar",
     "LoadExtensionSchemaUpdates": "WSS\\WSSHooks::onLoadExtensionSchemaUpdates",
     "CanonicalNamespaces": "WSS\\WSSHooks::onCanonicalNamespaces",
@@ -42,7 +43,8 @@
     "wss-add-space",
     "wss-archive-space",
     "wss-view-space-admins",
-    "wss-view-spaces-overview"
+    "wss-view-spaces-overview",
+    "wss-edit-protected"
   ],
   "GroupPermissions": {
     "sysop": {
@@ -58,6 +60,9 @@
       "wss-archive-space": true,
       "wss-view-space-admins": true,
       "wss-view-spaces-overview": true
+    },
+    "wss-protected-editor": {
+      "wss-edit-protected": true
     }
   },
   "ResourceModules": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -29,6 +29,7 @@
   "wss-unarchive-space-form-submit-text": "Unarchive this space",
   "wss-add-space-form-displayname-label": "Display name",
   "wss-add-space-form-description-label": "Description",
+  "wss-add-space-form-protected-label": "Protected",
   "wss-add-space-form-namespace-label": "Namespace Key",
   "wss-add-space-form-namespacename-label": "Namespace Name",
   "wss-add-space-form-namespace-help": "Namespace key must be unique. It will be used as a prefix for the pages in this space.",
@@ -107,6 +108,7 @@
   "wss-api-namespace-key-param": "The (case-sensitive) key of the namespace you want to get all the data for.",
   "wss-api-namespace-name-param": "The (case-sensitive) name of the namespace you want to get all the data for.",
   "wss-api-namespace-param": "The namespace you want to get the list of admins for.",
+  "wss-api-nsprotected-param": "Should the space be edit-protected to only certain users? String 'false' for not protected, unset for default (false on creation), anything else will make it protected.",
   "apihelp-addspace-example-foo": "Create the space 'Foo'.",
   "apihelp-archivespace-example-foo": "Archive the space 'Foo'.",
   "apihelp-unarchivespace-example-foo": "Unarchive the space 'Foo'.",
@@ -122,5 +124,10 @@
   "wss-pf-invalid-number": "The namespace parameter must be a positive number.",
   "wss-pf-no-admins-found": "No admins were found for namespace: $1",
   "wss-pf-no-valid-admins": "None of the admins for namespace: $1 are valid MediaWiki Users.",
-  "wss-space-not-wsspaces": "The space $1 is not managed by WSSpaces."
+  "wss-space-not-wsspaces": "The space $1 is not managed by WSSpaces.",
+  "group-wss-protected-editor": "Editors of protected spaces",
+  "group-wss-protected-editor-member": "Editor of protected spaces",
+  "right-wss-edit-protected": "Edit pages in protected spaces",
+  "action-wss-edit-protected": "edit pages in protected spaces",
+  "wss-edit-protected-page": "This space is protected, and you do not have the required rights to edit pages in protected spaces."
 }

--- a/sql/mysql/wss_namespaces_patch_2.sql
+++ b/sql/mysql/wss_namespaces_patch_2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*_*/wss_namespaces ADD COLUMN protected BOOLEAN NOT NULL DEFAULT FALSE;

--- a/sql/postgres/wss_namespaces_patch_2.sql
+++ b/sql/postgres/wss_namespaces_patch_2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*_*/wss_namespaces ADD COLUMN protected BOOLEAN NOT NULL DEFAULT FALSE;

--- a/sql/sqlite/wss_namespaces_patch_1.sql
+++ b/sql/sqlite/wss_namespaces_patch_1.sql
@@ -1,4 +1,4 @@
-#actually, this is not necessary: VARCHAR(64) is the same as VARCHAR(128) in sqlite
+--actually, this is not necessary: VARCHAR(64) is the same as VARCHAR(128) in sqlite
 PRAGMA foreign_keys=OFF;
 BEGIN TRANSACTION;
 CREATE TABLE /*_*/new_wss_namespaces (

--- a/sql/sqlite/wss_namespaces_patch_2.sql
+++ b/sql/sqlite/wss_namespaces_patch_2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE /*_*/wss_namespaces ADD COLUMN protected BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/API/ApiAddSpace.php
+++ b/src/API/ApiAddSpace.php
@@ -7,6 +7,7 @@ use MWException;
 use WSS\NamespaceRepository;
 use WSS\Space;
 use WSS\Validation\AddSpaceValidationCallback;
+use Wikimedia\ParamValidator\ParamValidator;
 
 class ApiAddSpace extends ApiBase {
 	/**
@@ -39,6 +40,7 @@ class ApiAddSpace extends ApiBase {
 		$ns_description = $request_params["nsdescription"];
 		$ns_admins = $request_params["nsadmins"];
 		$ns_admins = explode( ",", $ns_admins );
+		$ns_protected = isset( $request_params[ "nsprotected" ] ) && $request_params[ "nsprotected" ] !== 'false';
 
 		$current_user = \RequestContext::getMain()->getUser();
 
@@ -49,6 +51,8 @@ class ApiAddSpace extends ApiBase {
 		}
 
 		$space = Space::newFromValues( $ns_key, $ns_name, $ns_description, $current_user );
+		$space->setProtected( $ns_protected );
+
 		$namespace_repository = new NamespaceRepository();
 
 		$namespace_id = $namespace_repository->addSpace( $space );
@@ -130,21 +134,26 @@ class ApiAddSpace extends ApiBase {
 	public function getAllowedParams(): array {
 		return [
 			'nskey' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nskey-param"
 			],
 			'nsname' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nsname-param"
 			],
 			'nsdescription' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nsdescription-param"
 			],
 			'nsadmins' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nsadmins-param"
-			]
+			],
+			'nsprotected' => [
+				// We use string instead of boolean for consistency with EditSpace api
+				ParamValidator::PARAM_TYPE => "string",
+				ApiBase::PARAM_HELP_MSG => "wss-api-nsprotected-param"
+			],
 		];
 	}
 

--- a/src/API/ApiEditSpace.php
+++ b/src/API/ApiEditSpace.php
@@ -9,6 +9,7 @@ use User;
 use WSS\NamespaceRepository;
 use WSS\Space;
 use WSS\Validation\AddSpaceValidationCallback;
+use Wikimedia\ParamValidator\ParamValidator;
 
 class ApiEditSpace extends ApiBase {
 	/**
@@ -51,6 +52,7 @@ class ApiEditSpace extends ApiBase {
 		$ns_name = $request_params["nsname"] ?? null;
 		$ns_description = $request_params["nsdescription"] ?? null;
 		$ns_admins = $request_params[ "nsadmins" ] ?? null;
+		$ns_protected = $request_params[ "protected" ] ?? null;
 
 		$this->validateParams( $old_space, $ns_id, $ns_key, $ns_name, $ns_description );
 
@@ -73,6 +75,9 @@ class ApiEditSpace extends ApiBase {
 				$this->validateAdmins( $ns_admins );
 				$new_space->setSpaceAdministrators( $ns_admins );
 			}
+		}
+		if ( $ns_protected !== null ) {
+			$new_space->setProtected( $ns_protected !== 'false' );
 		}
 
 		try {
@@ -151,25 +156,30 @@ class ApiEditSpace extends ApiBase {
 	public function getAllowedParams(): array {
 		return [
 			'nsid' => [
-				ApiBase::PARAM_TYPE => "integer",
+				ParamValidator::PARAM_TYPE => "integer",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nsid-param"
 			],
 			'nskey' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nskey-param"
 			],
 			'nsname' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nsname-param"
 			],
 			'nsdescription' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nsdescription-param"
 			],
 			'nsadmins' => [
-				ApiBase::PARAM_TYPE => "string",
+				ParamValidator::PARAM_TYPE => "string",
 				ApiBase::PARAM_HELP_MSG => "wss-api-nsadmins-param"
-			]
+			],
+			'nsprotected' => [
+				// We do not use 'boolean' type, because we want to distinguish the 3 values 'true', 'false' and "unset"
+				ParamValidator::PARAM_TYPE => "string",
+				ApiBase::PARAM_HELP_MSG => "wss-api-nsprotected-param"
+			],
 		];
 	}
 

--- a/src/API/ApiEditSpace.php
+++ b/src/API/ApiEditSpace.php
@@ -52,7 +52,7 @@ class ApiEditSpace extends ApiBase {
 		$ns_name = $request_params["nsname"] ?? null;
 		$ns_description = $request_params["nsdescription"] ?? null;
 		$ns_admins = $request_params[ "nsadmins" ] ?? null;
-		$ns_protected = $request_params[ "protected" ] ?? null;
+		$ns_protected = $request_params[ "nsprotected" ] ?? null;
 
 		$this->validateParams( $old_space, $ns_id, $ns_key, $ns_name, $ns_description );
 

--- a/src/API/ApiQuerySingleSpace.php
+++ b/src/API/ApiQuerySingleSpace.php
@@ -50,6 +50,7 @@ class ApiQuerySingleSpace extends \ApiQueryBase {
 		$result->addValue( $space_id, "description", $space->getDescription() );
 		$result->addValue( $space_id, "owner", $space->getOwner() );
 		$result->addValue( $space_id, "admins", $space->getSpaceAdministrators() );
+		$result->addValue( $space_id, "protected", $space->isProtected() ? 'true' : 'false' );
 	}
 
 	/**

--- a/src/API/ApiQuerySpaces.php
+++ b/src/API/ApiQuerySpaces.php
@@ -36,6 +36,7 @@ class ApiQuerySpaces extends \ApiQueryBase {
 			$result->addValue( $space_id, "description", $space->getDescription() );
 			$result->addValue( $space_id, "owner", $space->getOwner() );
 			$result->addValue( $space_id, "admins", $space->getSpaceAdministrators() );
+			$result->addValue( $space_id, "protected", $space->isProtected() ? 'true' : 'false' );
 		}
 	}
 

--- a/src/Form/AddSpaceForm.php
+++ b/src/Form/AddSpaceForm.php
@@ -42,7 +42,12 @@ class AddSpaceForm extends AbstractForm {
 				'validation-callback' => function ( $field, $data ) {
 					return $this->getValidationCallback()->validateRequired( $field );
 				}
-			]
+			],
+			'protected' => [
+				'label-message' => 'wss-add-space-form-protected-label',
+				'type' => 'check',
+				'default' => false,
+			],
 		];
 	}
 

--- a/src/Form/EditSpaceForm.php
+++ b/src/Form/EditSpaceForm.php
@@ -83,6 +83,11 @@ class EditSpaceForm extends AbstractForm {
 					return $this->getValidationCallback()->validateRequired( $field );
 				}
 			],
+			'protected' => [
+				'label-message' => 'wss-add-space-form-protected-label',
+				'type' => 'check',
+				'default' => $this->space->isProtected(),
+			],
 			'administrators' => [
 				'label-message' => 'wss-manage-space-form-administrators-label',
 				'type' => 'usersmultiselect',

--- a/src/NamespaceRepository.php
+++ b/src/NamespaceRepository.php
@@ -242,6 +242,7 @@ class NamespaceRepository {
 			'namespace_key' => $space->getKey(),
 			'description' => $space->getDescription(),
 			'archived' => $space->isArchived() ? '1' : '0',
+			'protected' => $space->isProtected() ? '1' : '0',
 			'creator_id' => $space->getOwner()->getId(),
 			'created_on' => time()
 		] );
@@ -298,7 +299,8 @@ class NamespaceRepository {
 			'namespace_name' => $new_space->getName(),
 			'description' => $new_space->getDescription(),
 			'creator_id' => $new_space->getOwner()->getId(),
-			'archived' => $new_space->isArchived() ? '1' : '0'
+			'archived' => $new_space->isArchived() ? '1' : '0',
+			'protected' => $new_space->isProtected() ? '1' : '0',
 		], [
 			'namespace_id' => $old_space->getId()
 		] );

--- a/src/Space.php
+++ b/src/Space.php
@@ -484,7 +484,7 @@ class Space {
 	 */
 	public function canEditPages( $user = null ): bool {
 		$user ??= \RequestContext::getMain()->getUser();
-		return MediaWikiServices::getInstance()->getPermissionManager()->userHasRight(
+		return !$this->is_protected || MediaWikiServices::getInstance()->getPermissionManager()->userHasRight(
 			$user,
 			"wss-edit-protected"
 		);

--- a/src/SpacePager.php
+++ b/src/SpacePager.php
@@ -26,7 +26,8 @@ class SpacePager extends Pager {
 				'namespace_key',
 				'description',
 				'creator_id',
-				'created_on'
+				'created_on',
+				'protected'
 			],
 			'conds' => [
 				'archived' => '0'
@@ -82,6 +83,8 @@ class SpacePager extends Pager {
 				return $user->getName();
 			case 'created_on':
 				return date( "F jS, Y h:i:s", $value );
+			case 'protected':
+				return $value ? 'protected' : 'editable';
 			default:
 				return $value;
 		}
@@ -117,7 +120,8 @@ class SpacePager extends Pager {
 			'namespace_id' => "Namespace",
 			'description' => "Description",
 			'creator_id' => "Created by",
-			'created_on' => "Created on"
+			'created_on' => "Created on",
+			'protected' => "Protected",
 		];
 	}
 }

--- a/src/SubmitCallback/AddSpaceSubmitCallback.php
+++ b/src/SubmitCallback/AddSpaceSubmitCallback.php
@@ -45,15 +45,17 @@ class AddSpaceSubmitCallback implements SubmitCallback {
 		}
 
 		$description  = $form_data['description'];
-		$namespace_key    = $form_data['namespace'];
+		$namespace_key = $form_data['namespace'];
 		$namespace_name = $form_data['namespace_name'];
-
+		$protected = $form_data[ 'protected' ] ?? false;
 		$space = Space::newFromValues(
 			$namespace_key,
 			$namespace_name,
 			$description,
 			\RequestContext::getMain()->getUser()
 		);
+
+		$space->setProtected( $protected );
 
 		$namespace_repository = new NamespaceRepository();
 		$namespace_repository->addSpace( $space );

--- a/src/SubmitCallback/EditSpaceSubmitCallback.php
+++ b/src/SubmitCallback/EditSpaceSubmitCallback.php
@@ -57,6 +57,7 @@ class EditSpaceSubmitCallback implements SubmitCallback {
 		$new_space->setDescription( $form_data['description'] );
 		$new_space->setName( $form_data['namespace_name'] );
 		$new_space->setSpaceAdministrators( explode( "\n", $form_data['administrators'] ) );
+		$new_space->setProtected( $form_data[ 'protected' ] ?? false );
 
 		try {
 			$namespace_repository->updateSpace( $old_space, $new_space );


### PR DESCRIPTION
Add functionality to set some spaces as "protected", meaning only certain people (Those with the "wss-edit-protected" right) can edit these pages.

Please review if we want this functionality on master. Charly reviewed most code changes, but he did not want to decide about do we want this on master.

Please do not directly delete this branch when merging, we are pulling this branch as dev dependency.