### PR TITLE
MW1.39 compatible: Return string from getDescription of SpecialPages

### DIFF
--- a/src/Special/SpecialActiveSpaces.php
+++ b/src/Special/SpecialActiveSpaces.php
@@ -53,7 +53,11 @@ class SpecialActiveSpaces extends SpecialPage {
 	 * @inheritDoc
 	 */
 	public function getDescription() {
-		return $this->msg( 'wss-active-spaces-header' );
+		$msg = $this->msg( 'wss-active-spaces-header' );
+		if ( version_compare( MW_VERSION, '1.41' ) < 0 ) {
+			return $msg->plain();
+		}
+		return $msg;
 	}
 
 	/**

--- a/src/Special/SpecialAddSpace.php
+++ b/src/Special/SpecialAddSpace.php
@@ -45,7 +45,11 @@ class SpecialAddSpace extends SpecialPage {
 	 * @inheritDoc
 	 */
 	public function getDescription() {
-		return $this->msg( 'wss-add-space-header' );
+		$msg = $this->msg( 'wss-add-space-header' );
+		if ( version_compare( MW_VERSION, '1.41' ) < 0 ) {
+			return $msg->plain();
+		}
+		return $msg;
 	}
 
 	/**

--- a/src/Special/SpecialArchivedSpaces.php
+++ b/src/Special/SpecialArchivedSpaces.php
@@ -53,7 +53,11 @@ class SpecialArchivedSpaces extends SpecialPage {
 	 * @inheritDoc
 	 */
 	public function getDescription() {
-		return $this->msg( 'wss-archived-spaces-header' );
+		$msg = $this->msg( 'wss-archived-spaces-header' );
+		if ( version_compare( MW_VERSION, '1.41' ) < 0 ) {
+			return $msg->plain();
+		}
+		return $msg;
 	}
 
 	/**


### PR DESCRIPTION
See [documentation](https://doc.wikimedia.org/mediawiki-core/REL1_41/php/classMediaWiki_1_1SpecialPage_1_1SpecialPage.html#a1661e583dba8a8bae5af4c2d94c9391f), this "getDescription" can only return Message since 1.41, so breaks on 1.39 